### PR TITLE
chore: add lanunch.json to simplify binding debug workflow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "configurations": [
+    {
+      "name": "debug-js",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "pwa-node"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "sourceLanguages": ["rust"],
+      "name": "debug-rust",
+      "program": "node",
+      "args": ["--inspect-brk", "test.js"],
+      "cwd": "${workspaceFolder}"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "debug-rolldown",
+      "configurations": ["debug-js", "debug-rust"]
+    }
+  ]
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,8 @@
+const path = require('path')
+
+const { rolldown } = require('./node-binding')
+
+async function main() {
+  const _code = await rolldown(path.resolve(__dirname, './node/__test__/fixtures/main.js'))
+}
+main()


### PR DESCRIPTION
we can debug js and rust together
https://user-images.githubusercontent.com/8898718/159534329-492f1491-41fb-4c26-97a0-18eb0ef28cc9.mov

I have to set the "program" property to the absolute path of node, because it conflicts with rolldown's node directory.


